### PR TITLE
Fix for backup link

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -14,7 +14,7 @@ h2 { font-size: 1.25em; line-height: 1.333em; margin: 0.5em 0; }
  * Socialite
  */
 
-.socialite-button { display: none; opacity: 0; }
+.socialite-button, .socialite-button a { display: block; height: 100%; }
 .socialite-loaded .socialite-button { display: block; opacity: 1; }
 .socialite-button iframe { max-width: 100%; max-height: 100%; }
 


### PR DESCRIPTION
Fixed Example CSS to show socialite-button div and link as a backup when visitor has blocker enabled
