### PR TITLE
Added trim() in removeClass to prevent space creep in el.className

### DIFF
--- a/socialite.js
+++ b/socialite.js
@@ -33,7 +33,7 @@ window.Socialite = (function(window, document, undefined)
 
         removeClass: function(el, cn)
         {
-            el.className = (' ' + el.className + ' ').replace(' ' + cn + ' ', '');
+            el.className = (' ' + el.className + ' ').replace(' ' + cn + ' ', '').trim();
         },
 
         /**
@@ -459,7 +459,13 @@ window.Socialite = (function(window, document, undefined)
         }
 
     };
-
+   
+    if (!String.prototype.trim) {
+        String.prototype.trim = function () {
+            return this.replace(/^\s+|\s+$/g,'');  
+        };
+    }
+    
     return socialite;
 
 })(window, window.document);


### PR DESCRIPTION
Added trim() in removeClass to handle the case when it is called against a non-empty el.className set that does NOT include the to-be-removed class. Without this, spaces will be left on the front and back of the el.className. Since this is a frameworkless project, added String.prototype.trim if not native.
