### PR TITLE
Allowing re-parsing of inserted Pinterest links

### DIFF
--- a/extensions/socialite.pinterest.js
+++ b/extensions/socialite.pinterest.js
@@ -10,7 +10,8 @@
 
     Socialite.network('pinterest', {
         script: {
-            src: '//assets.pinterest.com/js/pinit.js'
+            src: '//assets.pinterest.com/js/pinit.js',
+            'data-pin-build': 'parsePinBtns'
         }
     });
 
@@ -39,7 +40,7 @@
             el.setAttribute('count-layout', instance.el.getAttribute('data-count-layout') || 'horizontal');
             instance.el.appendChild(el);
             if (Socialite.networkReady('pinterest')) {
-                Socialite.reloadNetwork('pinterest');
+                window.parsePinBtns();
             }
         }
     });


### PR DESCRIPTION
Links added to the DOM, properly tagged for Socialite, would not be
re-parsed as buttons by the Pinterest script.  This commit adds a
'data-pin-build' attribute to the pinit.js script tag to expose the
parsePinBtns() function and replaces the reloadNetwork call with a call
to this function.

I am currently using my modified code at http://tilearray.com to change Pinterest button properties when a mosaic's owner makes changes via an AJAX call.  To demo:

<ol>
<li>Visit the site and make a mosaic</li>
<li>Click the Pinterest button to begin a share</li>
<li>Close the window without sharing</li>
<li>Add a title for your mosaic</li>
<li>Click the Pinterest button again</li>
</ol>


Let me know if I'm not doing something "the Socialite way".  :-)
