### PR TITLE
Fix the Buffer button src URL

### DIFF
--- a/extensions/socialite.bufferapp.js
+++ b/extensions/socialite.bufferapp.js
@@ -10,7 +10,7 @@
 
     Socialite.network('bufferapp', {
         script: {
-            src: '//static.bufferapp.com/js/button.js'
+            src: '//d389zggrogs7qo.cloudfront.net/js/button.js'
         }
     });
 


### PR DESCRIPTION
The old URL doesn't work on https websites
