### PR TITLE
use latest Facebook Javascript SDK to maintain continued support

### DIFF
--- a/socialite.js
+++ b/socialite.js
@@ -498,7 +498,7 @@ window.Socialite = (function(window, document, undefined)
 
     Socialite.network('facebook', {
         script: {
-            src : '//connect.facebook.net/{{language}}/all.js',
+            src : '//connect.facebook.net/{{language}}/sdk.js',
             id  : 'facebook-jssdk'
         },
         append: function(network)
@@ -512,7 +512,8 @@ window.Socialite = (function(window, document, undefined)
             window.fbAsyncInit = function() {
                 window.FB.init({
                       appId: settings.appId,
-                      xfbml: true
+                      xfbml: true,
+                      version: 'v2.2'
                 });
                 for (var e in events) {
                     if (typeof settings[e] === 'function') {


### PR DESCRIPTION
Facebook is deprecating V1.0 of their API on April 30th, 2015. To maintain continued support for the Facebook Like plugin, it is necessary to provide a version and use their JavaScript SDK.

Facebook requests for the Like plugin now include the version -

```
https://www.facebook.com/v2.2/plugins/like.php?...
```

Further Reading:
https://developers.facebook.com/docs/apps/upgrading
https://developers.facebook.com/docs/apps/changelog
