### PR TITLE
Better support multiple buttons on a page

### DIFF
--- a/extensions/socialite.vkontakte.js
+++ b/extensions/socialite.vkontakte.js
@@ -28,8 +28,8 @@
 
     Socialite.network('vkontakte', {
         script: {
-            src : '//userapi.com/js/api/openapi.js?49',
-            id  : 'vk-jsapi'
+            src: '//userapi.com/js/api/openapi.js?49',
+            id : 'vk-jsapi'
         },
         onload: function(network) {
            var settings = Socialite.settings.vkontakte;
@@ -64,17 +64,23 @@
     Socialite.widget('vkontakte', 'like', {
         init: function(instance)
         {
-            if (typeof window.VK !== 'object') VKCallbacks.push(function(){
+            function initVKLike() {
                 var el       = document.createElement('div'),
                     settings = Socialite.settings.vkontakte;
                 el.className = 'vk-like';
                 // Vkontakte needs explicit element id
                 el.id = 'vkontakte-like-' + (new Date()).getTime() + Math.random().toString().replace('.', '-');
                 Socialite.copyDataAttributes(instance.el, el);
-                like = extendConfWithAttributes(instance.el, ['type'], settings.like);
+                like = extendConfWithAttributes(instance.el, ['type', 'pageUrl', 'height'], settings.like);
                 instance.el.appendChild(el);
                 VK.Widgets.Like(el.id, like);
-            });
+            }
+            
+            if (typeof window.VK !== 'object') { 
+                VKCallbacks.push(initVKLike);
+            } else {
+                initVKLike();
+            }
         }
     });
 


### PR DESCRIPTION
Now if you try to use Socialite with Vkontakte, it will work only when loaded the first time — on the second load new Vkontakte buttons won’t appear (Facebook and Twitter work fine). But I wanted to call ```Socialite.load()``` every time an event if fired to load buttons for a specific post. 

This fixed it for me and this is how I’m using it:

```
$('.js-open-like').click(function() {
      $(this).next('.js-like-share-popup').toggleClass('is-open');
      Socialite.load(
        $(this).next('.js-like-share-popup')[0]
      );
});
```

Provided there are multiple ```.js-open-like``` buttons and ```.js-like-share-popup``` containers on the page.

Also added support for data-height and data-pageUrl attributes.